### PR TITLE
Implemented #137 - Manual execute single topic/tracker shouldn't reset timeout

### DIFF
--- a/monitorrent/engine.py
+++ b/monitorrent/engine.py
@@ -12,7 +12,7 @@ import html
 
 from sqlalchemy import Column, Integer, ForeignKey, Unicode, Enum, func
 from monitorrent.db import Base, DBSession, row2dict, UTCDateTime
-
+from monitorrent.utils.timers import timer
 
 class Logger(object):
     def started(self, start_time):
@@ -252,15 +252,6 @@ class ExecuteLogManager(object):
             return None
 
         return self.get_execute_log_details(self._execute_id, after)
-
-# TODO add test case for timer
-def timer(interval, timer_func, *args, **kwargs):
-    stopped = threading.Event()
-    def loop_fn():
-        while not stopped.wait(interval):
-            timer_func(*args, **kwargs)
-    threading.Thread(target=loop_fn).start()    
-    return stopped.set
 
 
 class EngineRunner(threading.Thread):

--- a/monitorrent/engine.py
+++ b/monitorrent/engine.py
@@ -3,7 +3,7 @@ from builtins import object
 import sys
 import threading
 
-from Queue import PriorityQueue
+from queue import PriorityQueue
 from collections import namedtuple
 from datetime import datetime, timedelta
 

--- a/monitorrent/utils/timers.py
+++ b/monitorrent/utils/timers.py
@@ -1,14 +1,11 @@
-from builtins import object
-
-import sys
 import threading
-
 
 
 def timer(interval, timer_func, *args, **kwargs):
     stopped = threading.Event()
+
     def loop_fn():
         while not stopped.wait(interval):
             timer_func(*args, **kwargs)
-    threading.Thread(target=loop_fn).start()    
+    threading.Thread(target=loop_fn).start()
     return stopped.set

--- a/monitorrent/utils/timers.py
+++ b/monitorrent/utils/timers.py
@@ -1,0 +1,14 @@
+from builtins import object
+
+import sys
+import threading
+
+
+
+def timer(interval, timer_func, *args, **kwargs):
+    stopped = threading.Event()
+    def loop_fn():
+        while not stopped.wait(interval):
+            timer_func(*args, **kwargs)
+    threading.Thread(target=loop_fn).start()    
+    return stopped.set

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -356,10 +356,6 @@ class EngineRunnerTest(TestCase):
 
         execute_mock.assert_called_once_with(ANY, None)
 
-
-
-    # TODO add case for single topic/tracker
-    # manual execute !!!SHOULD reset it for whole list of topics
     def test_manual_execute_shouldnt_reset_timeout_for_whole_execute(self):
         executed = Event()
 
@@ -369,10 +365,10 @@ class EngineRunnerTest(TestCase):
 
         execute_mock = Mock(side_effect=execute)
         self.trackers_manager.execute = execute_mock
-        
+
         # start
         self.create_runner(interval=1)
-        
+
         sleep(0.5)
         # start manual
         self.engine_runner.execute([1, 2, 3])

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -154,13 +154,13 @@ class EngineRunnerTest(TestCase):
         self.engine_runner.stop()
         self.engine_runner.join(1)
 
-    def test_stop_bofore_execute(self):        
+    def test_stop_bofore_execute(self):
         execute_mock = MagicMock()
         self.trackers_manager.execute = execute_mock
-        
+
         self.create_runner()
         self.stop_runner()
-        
+
         self.assertFalse(self.engine_runner.is_alive())
 
         execute_mock.assert_not_called()

--- a/tests/utils/test_timers.py
+++ b/tests/utils/test_timers.py
@@ -1,0 +1,43 @@
+from builtins import object
+
+from time import sleep
+from tests import TestCase
+from mock import MagicMock
+from monitorrent.utils.timers import timer
+
+
+class EngineTest(TestCase):
+    def setUp(self):
+        super(EngineTest, self).setUp()
+
+    def test_timer_runs_continiously(self):
+        execute_mock = MagicMock()
+
+        cancel = timer(0.1, execute_mock)
+
+        sleep(0.5)
+        cancel()
+        self.assertTrue(execute_mock.call_count > 2)
+
+    def test_timer_passes_arguments_to_timer_func(self):
+        execute_mock = MagicMock()
+        cancel = timer(0.1, execute_mock, 'foo', bar='baz')
+
+        sleep(0.2)
+        cancel()
+
+        execute_mock.assert_called_once_with('foo', bar='baz')
+        
+    
+    def test_timer_dont_run_after_cancellation(self):
+        execute_mock = MagicMock()
+        cancel = timer(0.1, execute_mock)
+
+        sleep(0.5)
+        cancel()
+
+        self.assertTrue(execute_mock.call_count > 2)
+        expected_call_count = execute_mock.call_count
+
+        sleep(0.5)
+        self.assertEqual(execute_mock.call_count, expected_call_count)

--- a/tests/utils/test_timers.py
+++ b/tests/utils/test_timers.py
@@ -1,5 +1,3 @@
-from builtins import object
-
 from time import sleep
 from tests import TestCase
 from mock import MagicMock
@@ -27,8 +25,7 @@ class EngineTest(TestCase):
         cancel()
 
         execute_mock.assert_called_once_with('foo', bar='baz')
-        
-    
+
     def test_timer_dont_run_after_cancellation(self):
         execute_mock = MagicMock()
         cancel = timer(0.1, execute_mock)


### PR DESCRIPTION
#137 Implemented timer via separate thread pushing messages to worker's priority queue.
Added two types of message:
- stop_message that has the highest priority
- run_message that can be parametrized with list of ids 

Added unit tests just to `engine.py`.
Not sure if api tests are needed here, will add them if needed.