### PR TITLE
#137 Fixed several issues with default value for DBEngineRunner.interval

### DIFF
--- a/monitorrent/utils/timers.py
+++ b/monitorrent/utils/timers.py
@@ -7,5 +7,9 @@ def timer(interval, timer_func, *args, **kwargs):
     def loop_fn():
         while not stopped.wait(interval):
             timer_func(*args, **kwargs)
-    threading.Thread(target=loop_fn).start()
+
+    thread = threading.Thread(target=loop_fn, name="timer")
+    thread.daemon = True
+    thread.start()
+
     return stopped.set

--- a/tests/utils/test_timers.py
+++ b/tests/utils/test_timers.py
@@ -1,6 +1,6 @@
 from time import sleep
 from tests import TestCase
-from mock import MagicMock
+from mock import MagicMock, patch
 from monitorrent.utils.timers import timer
 
 
@@ -39,3 +39,17 @@ class TimersTest(TestCase):
 
         sleep(0.5)
         self.assertEqual(execute_mock.call_count, expected_call_count)
+
+    def test_timer_starts_daemon_thread(self):
+        execute_mock = MagicMock()
+        timer_thread = MagicMock()
+
+        with patch('threading.Thread') as thread_mock:
+            thread_mock.return_value = timer_thread
+
+            cancel = timer(0.1, execute_mock)
+
+            assert hasattr(timer_thread, "daemon")
+            assert timer_thread.daemon is True
+
+            cancel()


### PR DESCRIPTION
- `_create_timer()` was not called on `interval` property setter. Overriding properties `interval` and `last_execute` copy behavior from EngineRunner. This solution is simpler comparing to calling overridden properties of base class from child class, tests ensure consistency.
- Added `daemon=True` for EngineRunner and timer threads.
- Added maxi-tor.org to list of domain names for rutor.info