### PR TITLE
Added maxi-tor.org as rutor mirror

### DIFF
--- a/monitorrent/plugins/trackers/rutor.py
+++ b/monitorrent/plugins/trackers/rutor.py
@@ -98,7 +98,7 @@ def upgrade_1_to_2(operations_factory):
 
 class RutorOrgTracker(object):
     tracker_settings = None
-    tracker_domains = ['rutor.info', 'rutor.is', 'new-tor.org']
+    tracker_domains = ['rutor.info', 'rutor.is', 'new-tor.org', 'maxi-tor.org']
     _regex = re.compile(u'^/torrent/(\d+)(/.*)?$')
     title_headers = ["rutor.info ::", u'зеркало rutor.info :: ']
 


### PR DESCRIPTION
```
$ http maxi-tor.org
HTTP/1.1 301 http://rutor.info/
Connection: keep-alive
Content-Length: 0
Date: Tue, 15 Nov 2016 07:33:46 GMT
Location: http://rutor.info/
```