### PR TITLE
(dirty fix) rename cookie 'bb_data' to 'bb_session'

### DIFF
--- a/monitorrent/plugins/trackers/rutracker.py
+++ b/monitorrent/plugins/trackers/rutracker.py
@@ -84,7 +84,7 @@ class RutrackerTracker(object):
             # it can contain request to enter capture, so we should handle it
             raise RutrackerLoginFailedException(1, "Invalid login or password")
         else:
-            bb_data = s.cookies.get('bb_data')
+            bb_data = s.cookies.get('bb_session')
             if not bb_data:
                 raise RutrackerLoginFailedException(2, "Failed to retrieve cookie")
 
@@ -104,7 +104,7 @@ class RutrackerTracker(object):
     def get_cookies(self):
         if not self.bb_data:
             return False
-        return {'bb_data': self.bb_data}
+        return {'bb_session': self.bb_data}
 
     def get_id(self, url):
         match = self._regex.match(url)

--- a/tests/cassettes/test_rutrackerplugin.RutrackerPluginTest.test_login_verify_success
+++ b/tests/cassettes/test_rutrackerplugin.RutrackerPluginTest.test_login_verify_success
@@ -18,7 +18,7 @@ interactions:
       date: ['Sun, 18 Dec 2016 20:37:14 GMT']
       location: ['https://rutracker.org/forum/index.php']
       server: [nginx]
-      set-cookie: ['bb_data=1-39956468-SCnxRRVOYVKbWc5NTZ8f-0-1482092928-1482093387-679265000-0;
+      set-cookie: ['bb_session=1-39956468-SCnxRRVOYVKbWc5NTZ8f-0-1482092928-1482093387-679265000-0;
           expires=Wed, 16-Dec-2026 20:37:14 GMT; Max-Age=315360000; path=/forum/;
           domain=.rutracker.org; secure; httponly', 'bb_ssl=1; expires=Wed, 16-Dec-2026
           20:37:14 GMT; Max-Age=315360000; path=/forum/; domain=.rutracker.org']
@@ -29,7 +29,7 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Cookie: [bb_data=1-39956468-SCnxRRVOYVKbWc5NTZ8f-0-1482092928-1482093387-679265000-0;
+      Cookie: [bb_session=1-39956468-SCnxRRVOYVKbWc5NTZ8f-0-1482092928-1482093387-679265000-0;
           bb_ssl=1]
       User-Agent: [python-requests/2.12.4]
     method: GET
@@ -657,7 +657,7 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Cookie: [!!python/unicode 'bb_data=1-39956468-SCnxRRVOYVKbWc5NTZ8f-0-1482092928-1482093387-679265000-0']
+      Cookie: [!!python/unicode 'bb_session=1-39956468-SCnxRRVOYVKbWc5NTZ8f-0-1482092928-1482093387-679265000-0']
       User-Agent: [python-requests/2.12.4]
     method: GET
     uri: https://rutracker.org/forum/privmsg.php?folder=inbox

--- a/tests/cassettes/test_rutrackertracker.RutrackerTrackerTest.test_login
+++ b/tests/cassettes/test_rutrackertracker.RutrackerTrackerTest.test_login
@@ -18,7 +18,7 @@ interactions:
       date: ['Sun, 18 Dec 2016 20:48:25 GMT']
       location: ['https://rutracker.org/forum/index.php']
       server: [nginx]
-      set-cookie: ['bb_data=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440408614-2609875527-0;
+      set-cookie: ['bb_session=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440408614-2609875527-0;
           expires=Wed, 16-Dec-2026 20:48:25 GMT; Max-Age=315360000; path=/forum/;
           domain=.rutracker.org; secure; httponly', 'bb_ssl=1; expires=Wed, 16-Dec-2026
           20:48:25 GMT; Max-Age=315360000; path=/forum/; domain=.rutracker.org']
@@ -29,7 +29,7 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Cookie: [bb_data=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440408614-2609875527-0;
+      Cookie: [bb_session=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440408614-2609875527-0;
           bb_ssl=1]
       User-Agent: [python-requests/2.12.4]
     method: GET
@@ -649,7 +649,7 @@ interactions:
       expires: ['0']
       pragma: [no-cache]
       server: [nginx]
-      set-cookie: ['bb_data=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440408614-2609875527-0;
+      set-cookie: ['bb_session=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440408614-2609875527-0;
           expires=Wed, 16-Dec-2026 20:48:25 GMT; Max-Age=315360000; path=/forum/;
           domain=.rutracker.org; secure; httponly', 'bb_ssl=1; expires=Wed, 16-Dec-2026
           20:48:25 GMT; Max-Age=315360000; path=/forum/; domain=.rutracker.org']

--- a/tests/cassettes/test_rutrackertracker.RutrackerTrackerTest.test_verify
+++ b/tests/cassettes/test_rutrackertracker.RutrackerTrackerTest.test_verify
@@ -18,7 +18,7 @@ interactions:
       date: ['Sun, 18 Dec 2016 20:52:47 GMT']
       location: ['https://rutracker.org/forum/index.php']
       server: [nginx]
-      set-cookie: ['bb_data=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440419425-2609875527-0;
+      set-cookie: ['bb_session=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440419425-2609875527-0;
           expires=Wed, 16-Dec-2026 20:52:47 GMT; Max-Age=315360000; path=/forum/;
           domain=.rutracker.org; secure; httponly', 'bb_ssl=1; expires=Wed, 16-Dec-2026
           20:52:47 GMT; Max-Age=315360000; path=/forum/; domain=.rutracker.org']
@@ -29,7 +29,7 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Cookie: [bb_data=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440419425-2609875527-0;
+      Cookie: [bb_session=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440419425-2609875527-0;
           bb_ssl=1]
       User-Agent: [python-requests/2.12.4]
     method: GET
@@ -657,7 +657,7 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Cookie: [bb_data=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440419425-2609875527-0]
+      Cookie: [bb_session=1-15564713-ELKc8t23nmllV4gydkNx-634753855-1440364056-1440419425-2609875527-0]
       User-Agent: [python-requests/2.12.4]
     method: GET
     uri: https://rutracker.org/forum/privmsg.php?folder=inbox

--- a/tests/plugins/trackers/rutracker/test_rutrackerplugin.py
+++ b/tests/plugins/trackers/rutracker/test_rutrackerplugin.py
@@ -83,7 +83,7 @@ class RutrackerPluginTest(DbTestCase):
             self.assertEqual(self.plugin.update_credentials(credentials), LoginResult.Unknown)
 
     def test_prepare_request(self):
-        cookies = {'bb_data': '1-4301487-ZdJuaHIfHpaJiVn8VPKU-0-1461694123-1461698647-4135149312-1'}
+        cookies = {'bb_session': '1-4301487-ZdJuaHIfHpaJiVn8VPKU-0-1461694123-1461698647-4135149312-1'}
         # noinspection PyUnresolvedReferences
         with patch.object(self.plugin.tracker, 'get_cookies', result=cookies):
             url = 'http://rutracker.org/forum/viewtopic.php?t=5062041'

--- a/tests/plugins/trackers/rutracker/test_rutrackertracker.py
+++ b/tests/plugins/trackers/rutracker/test_rutrackertracker.py
@@ -93,7 +93,7 @@ class RutrackerTrackerTest(TestCase):
         self.assertFalse(self.tracker.get_cookies())
         self.tracker = RutrackerTracker(self.helper.real_uid, self.helper.real_bb_data)
         self.tracker.tracker_settings = self.tracker_settings
-        self.assertEqual(self.tracker.get_cookies()['bb_data'], self.helper.real_bb_data)
+        self.assertEqual(self.tracker.get_cookies()['bb_session'], self.helper.real_bb_data)
 
     def test_get_id(self):
         for url in self.urls_to_check:


### PR DESCRIPTION
Очень быстрый и грязный фикс (переименование bb_data в bb_session).
Пардон, но кассеты для тестов тут обновить нет возможности, все заблокировано.