### PR TITLE
Qbittorrent add torrent fixes (wait for async add)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ report.html
 /MonitorrentInstaller/vcredist/
 /MonitorrentInstaller/nssm/
 /MonitorrentInstaller/nssm.zip
+
+/.clients/

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -1,0 +1,19 @@
+---
+version: "2.1"
+services:
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:latest
+    container_name: qbittorrent
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      - WEBUI_PORT=8080
+    volumes:
+      - ./.clients/qbittorrent/config:/config
+      - ./.clients/qbittorrent/downloads:/downloads
+    ports:
+      - 8080:8080
+      - 6881:6881
+      - 6881:6881/udp
+    restart: unless-stopped

--- a/monitorrent/plugins/clients/qbittorrent.py
+++ b/monitorrent/plugins/clients/qbittorrent.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import six
+import time
 
 from pytz import utc
 from sqlalchemy import Column, Integer, String
@@ -12,6 +13,7 @@ from qbittorrentapi import Client
 
 from monitorrent.db import Base, DBSession
 from monitorrent.plugin_managers import register_plugin
+from monitorrent.utils.bittorrent_ex import Torrent
 from datetime import datetime
 
 
@@ -57,6 +59,12 @@ class QBittorrentClientPlugin(object):
     DEFAULT_PORT = 8080
     SUPPORTED_FIELDS = ['download_dir']
     ADDRESS_FORMAT = "{0}:{1}"
+    _client = None
+
+    def get_client(self):
+        if not self._client:
+            self._client = self._get_client()
+        return self._client
 
     def _get_client(self):
         with DBSession() as db:
@@ -96,10 +104,15 @@ class QBittorrentClientPlugin(object):
             cred.password = settings.get('password', None)
 
     def check_connection(self):
-        return self._get_client()
+        try:
+            client = self.get_client()
+            client.app_version()
+            return True
+        except:
+            return False
 
     def find_torrent(self, torrent_hash):
-        client = self._get_client()
+        client = self.get_client()
         if not client:
             return False
 
@@ -117,7 +130,7 @@ class QBittorrentClientPlugin(object):
             return False
 
     def get_download_dir(self):
-        client = self._get_client()
+        client = self.get_client()
         if not client:
             return None
 
@@ -127,11 +140,11 @@ class QBittorrentClientPlugin(object):
         except:
             return None
 
-    def add_torrent(self, torrent, torrent_settings):
+    def add_torrent(self, torrent_content, torrent_settings):
         """
         :type torrent_settings: clients.TopicSettings | None
         """
-        client = self._get_client()
+        client = self.get_client()
         if not client:
             return False
 
@@ -142,13 +155,26 @@ class QBittorrentClientPlugin(object):
                 savepath = torrent_settings.download_dir
                 auto_tmm = False
 
-            res = client.torrents_add(save_path=savepath, use_auto_torrent_management=auto_tmm, torrent_contents=[('file.torrent', torrent)])
-            return res
+            res = client.torrents_add(save_path=savepath, use_auto_torrent_management=auto_tmm, torrent_contents=[('file.torrent', torrent_content)])
+            if 'Ok' in res:
+                torrent = Torrent(torrent_content)
+                torrent_hash = torrent.info_hash
+                repeat_cnt = 30
+                while True:
+                    found = self.find_torrent(torrent_hash)
+                    if found:
+                        return True
+                    if repeat_cnt == 0:
+                        return False
+                    time.sleep(1)
+                    repeat_cnt -= 1
+
+            return False
         except:
             return False
 
     def remove_torrent(self, torrent_hash):
-        client = self._get_client()
+        client = self.get_client()
         if not client:
             return False
 

--- a/monitorrent/plugins/clients/qbittorrent.py
+++ b/monitorrent/plugins/clients/qbittorrent.py
@@ -159,15 +159,11 @@ class QBittorrentClientPlugin(object):
             if 'Ok' in res:
                 torrent = Torrent(torrent_content)
                 torrent_hash = torrent.info_hash
-                repeat_cnt = 30
-                while True:
+                for i in range(0, 10):
                     found = self.find_torrent(torrent_hash)
                     if found:
                         return True
-                    if repeat_cnt == 0:
-                        return False
                     time.sleep(1)
-                    repeat_cnt -= 1
 
             return False
         except:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ SQLAlchemy-Enum34==1.0.1
 transmissionrpc==0.11
 beautifulsoup4==4.7.1
 deluge-client==1.7.0
-qbittorrent-api==0.5.1
+qbittorrent-api==2021.3.18
 feedparser==6.0.8
 alembic==1.0.8
 falcon==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ SQLAlchemy-Enum34==1.0.1
 transmissionrpc==0.11
 beautifulsoup4==4.7.1
 deluge-client==1.7.0
-qbittorrent-api==2021.3.18
+qbittorrent-api==2023.3.44
 feedparser==6.0.8
 alembic==1.0.8
 falcon==1.4.1

--- a/tests/plugins/clients/test_qbittorrent.py
+++ b/tests/plugins/clients/test_qbittorrent.py
@@ -12,14 +12,14 @@ import qbittorrentapi
 import monitorrent.plugins.trackers
 from monitorrent.plugins.clients import TopicSettings
 from monitorrent.plugins.clients.qbittorrent import QBittorrentClientPlugin
-from tests import DbTestCase, use_vcr
+from tests import DbTestCase, ReadContentMixin, use_vcr
 from mock import patch, Mock
 
 def new(name, data):
     return type(name, (object,), data)
 
 @ddt
-class QBittorrentPluginTest(DbTestCase):
+class QBittorrentPluginTest(ReadContentMixin, DbTestCase):
     DEFAULT_SETTINGS = {'host': 'localhost', 'username': 'monitorrent', 'password': 'monitorrent'}
 
     def test_settings(self):
@@ -128,27 +128,45 @@ class QBittorrentPluginTest(DbTestCase):
 
     @patch('monitorrent.plugins.clients.qbittorrent.Client')
     def test_add_torrent_success(self, qbittorrent_client):
+        torrent = self.read_httpretty_content('Hell.On.Wheels.S05E02.720p.WEB.rus.LostFilm.TV.mp4.torrent', 'rb')
         client = qbittorrent_client.return_value
         client.torrents_add.return_value = 'Ok.'
+        torrent_info = [
+            new('torrent', {
+                'name': 'Hell.On.Wheels.S05E02.720p.WEB.rus.LostFilm.TV.mp4',
+                'info': new('info', {
+                    "added_on": 1616424630
+                })
+            })
+        ]
+        client.torrents_info.return_value = torrent_info
 
         plugin = QBittorrentClientPlugin()
         settings = self.DEFAULT_SETTINGS
         plugin.set_settings(settings)
 
-        torrent = b'torrent'
-        self.assertEqual('Ok.', plugin.add_torrent(torrent, None))
+        self.assertEqual(True, plugin.add_torrent(torrent, None))
 
     @patch('monitorrent.plugins.clients.qbittorrent.Client')
     def test_add_torrent_with_settings_success(self, qbittorrent_client):
+        torrent = self.read_httpretty_content('Hell.On.Wheels.S05E02.720p.WEB.rus.LostFilm.TV.mp4.torrent', 'rb')
         client = qbittorrent_client.return_value
         client.torrents_add.return_value = 'Ok.'
+        torrent_info = [
+            new('torrent', {
+                'name': 'Hell.On.Wheels.S05E02.720p.WEB.rus.LostFilm.TV.mp4',
+                'info': new('info', {
+                    "added_on": 1616424630
+                })
+            })
+        ]
+        client.torrents_info.return_value = torrent_info
 
         plugin = QBittorrentClientPlugin()
         settings = self.DEFAULT_SETTINGS
         plugin.set_settings(settings)
 
-        torrent = b'torrent'
-        self.assertEqual('Ok.', plugin.add_torrent(torrent, TopicSettings("/path/to/download")))
+        self.assertEqual(True, plugin.add_torrent(torrent, TopicSettings("/path/to/download")))
 
     @patch('monitorrent.plugins.clients.qbittorrent.Client')
     def test_remove_torrent_bad_settings(self, qbittorrent_client):


### PR DESCRIPTION
В api qbittorrent процесс добавления нового торрента асинхронный - операция torrents_add завершается раньше, нежели добавленный торрент становится виден через интерфейс и api torrents_info.
Интерфейс плагинов monitorrent, судя по всему, рассчитывает на синхронное завершение операции add_torrent.

В PR добавлена синхронизация: внутри add_torrent после добавления осуществляется поллинг torrents_info до тех пор, пока вновь добавленный торрент не появится, но не более, чем 30 раз с интервалом в 1 секунду.

Исправляет: #350

PS: Если что не так по стилю и т.д. - правьте сразу, я не умею в питон, не знаю как там принято писать и т.д.