### PR TITLE
fix(lostfilm.tv): add domain setting to support aliases without Cloudflare

### DIFF
--- a/monitorrent/plugins/trackers/lostfilm.py
+++ b/monitorrent/plugins/trackers/lostfilm.py
@@ -744,12 +744,18 @@ class LostFilmPlugin(WithCredentialsMixin, TrackerPluginBase):
         return result
 
     def prepare_add_topic(self, url):
-        parsed_url = self.tracker.parse_url(url)
-        if parsed_url is None or isinstance(parsed_url, Response):
-            return None
         with DBSession() as db:
             cred = db.query(self.credentials_class).first()
             quality = cred.default_quality if cred else 'SD'
+            session = cred.session if cred else None
+            domain = cred.domain if cred else 'www.lostfilm.tv'
+            cookies = json.loads(cred.cookies) if cred.cookies else None
+            headers = json.loads(cred.headers) if cred.headers else None
+        self.tracker.setup(session=session, headers=headers, cookies=cookies, domain=domain)
+        parsed_url = self.tracker.parse_url(url)
+        if parsed_url is None or isinstance(parsed_url, Response):
+            return None
+
         settings = {
             'display_name': self._get_display_name(parsed_url),
             'quality': quality

--- a/monitorrent/plugins/trackers/lostfilm.py
+++ b/monitorrent/plugins/trackers/lostfilm.py
@@ -46,7 +46,7 @@ class LostFilmTVCredentials(Base):
     session = Column(String, nullable=True)
     cookies = Column(String, nullable=True)
     headers = Column(String, nullable=True)
-    domain = Column(String, nullable=True, server_default='www.lostfilmtv.site')
+    domain = Column(String, nullable=True, server_default='www.lostfilm.tv')
     default_quality = Column(String, nullable=False, server_default='SD')
 
 
@@ -80,7 +80,7 @@ def upgrade(engine, operations_factory):
         version = 5
     if version == 5:
         with operations_factory() as operations:
-            domain_column = Column('domain', String, nullable=True, server_default='www.lostfilmtv.site')
+            domain_column = Column('domain', String, nullable=True, server_default='www.lostfilm.tv')
             operations.add_column(LostFilmTVCredentials.__tablename__, domain_column)
         version = 6
 

--- a/monitorrent/plugins/trackers/lostfilm.py
+++ b/monitorrent/plugins/trackers/lostfilm.py
@@ -471,23 +471,23 @@ class LostFilmTVTracker(object):
                                   re.UNICODE)
     playwright_timeout = 30000
 
-    def __init__(self, headers_cookies_updater=lambda h, c: None, session=None, headers=None, cookies=None):
+    def __init__(self, headers_cookies_updater=lambda h, c: None, session=None, headers=None, cookies=None, domain=None):
         self.session = session
         self.headers = headers or {}
         self.cookies = cookies or {}
+        self.domain = domain or "www.lostfilm.tv"
         self.headers_cookies_updater = headers_cookies_updater
 
-    def set_domain(self, domain):
-        self.domain = domain
-
-    def setup(self, session=None, headers=None, cookies=None):
+    def setup(self, session=None, headers=None, cookies=None, domain=None):
         self.session = session
         self.headers = headers or {}
         self.cookies = cookies or {}
+        self.domain = domain or "www.lostfilm.tv"
 
-    def login(self, email, password, headers=None, cookies=None):
+    def login(self, email, password, headers=None, cookies=None, domain=None):
         self.headers = headers or {}
         self.cookies = cookies or {}
+        self.domain = domain or "www.lostfilm.tv"
         headers, cookies = update_headers_and_cookies_mixin(self, "https://" + self.domain)
 
         params = {"act": "users", "type": "login", "mail": email, "pass": password, "rem": 1, "need_captcha": "", "captcha": ""}
@@ -766,8 +766,7 @@ class LostFilmPlugin(WithCredentialsMixin, TrackerPluginBase):
             if not username or not password:
                 return LoginResult.CredentialsNotSpecified
         try:
-            self.tracker.login(username, password, headers, cookies)
-            self.tracker.set_domain(domain)
+            self.tracker.login(username, password, headers, cookies, domain)
             with DBSession() as db:
                 cred = db.query(self.credentials_class).first()
                 cred.session = self.tracker.session
@@ -796,8 +795,8 @@ class LostFilmPlugin(WithCredentialsMixin, TrackerPluginBase):
                 cred.session,
                 json.loads(cred.headers) if cred.headers else None,
                 json.loads(cred.cookies) if cred.cookies else None,
+                cred.domain,
             )
-            self.tracker.set_domain(cred.domain)
         return self.tracker.verify()
 
     def execute(self, topics, engine):

--- a/monitorrent/plugins/trackers/lostfilm.py
+++ b/monitorrent/plugins/trackers/lostfilm.py
@@ -660,7 +660,7 @@ class LostFilmPlugin(WithCredentialsMixin, TrackerPluginBase):
         'content': [{
             "type": "text",
             "model": "domain",
-            "label": "Domain",
+            "label": "Domain, you can specify any www.lostfilm.tv mirror, e.g. www.lostfilmtv.site",
             "flex": 100
         }]
     }, {

--- a/tests/plugins/trackers/tests_lostfilm/test_lostfilmtracker.py
+++ b/tests/plugins/trackers/tests_lostfilm/test_lostfilmtracker.py
@@ -106,7 +106,7 @@ class TestLosfFilmShow(object):
         season1 = LostFilmSeason(1)
         season2 = LostFilmSeason(2)
 
-        show = LostFilmShow('Show', u'Шоу', 'Show', 2017)
+        show = LostFilmShow('Show', u'Шоу', 'Show', 2017, 'www.lostfilm.tv')
 
         assert show.last_season is None
         assert show.seasons_url == 'https://www.lostfilm.tv/series/Show/seasons'
@@ -126,7 +126,7 @@ class TestLosfFilmShow(object):
     def test_special_season_shouldnot_became_last_season(self):
         season1 = LostFilmSeason(SpecialSeasons.Additional)
 
-        show = LostFilmShow('Show', u'Шоу', 'Show', 2017)
+        show = LostFilmShow('Show', u'Шоу', 'Show', 2017, 'www.lostfilm.tv')
 
         assert show.last_season is None
         assert show.seasons_url == 'https://www.lostfilm.tv/series/Show/seasons'
@@ -145,7 +145,7 @@ class TestLosfFilmShow(object):
     def test_add_episode_failed(self):
         season1 = LostFilmSeason(2)
 
-        show = LostFilmShow('Show', u'Шоу', 'Show', 2017)
+        show = LostFilmShow('Show', u'Шоу', 'Show', 2017, 'www.lostfilm.tv')
 
         assert show.seasons_url == 'https://www.lostfilm.tv/series/Show/seasons'
 
@@ -173,7 +173,7 @@ class TestLosfFilmShow(object):
         ('https://www.lostfilm.tv/not/The_Expanse/seasons', None),
     ])
     def test_get_seasons_url(self, url, expected_url):
-        assert LostFilmShow.get_seasons_url(url) == expected_url
+        assert LostFilmShow.get_seasons_url(url, 'www.lostfilm.tv') == expected_url
 
 
 class TestLostFilmQuality(object):

--- a/tests/plugins/trackers/tests_lostfilm/test_lostfilmtracker_upgrade.py
+++ b/tests/plugins/trackers/tests_lostfilm/test_lostfilmtracker_upgrade.py
@@ -89,6 +89,22 @@ class LostFilmTrackerUpgradeTest(UpgradeTestCase):
                                    Column('cookies', String),
                                    Column('headers', String),
                                    Column('default_quality', String, nullable=False, server_default='SD'))
+    m6 = MetaData()
+    Topic6 = UpgradeTestCase.copy(Topic.__table__, m6)
+    LostFilmTVSeries6 = Table('lostfilmtv_series', m6,
+                              Column("id", Integer, ForeignKey('topics.id'), primary_key=True),
+                              Column("cat", Integer, nullable=False),
+                              Column("season", Integer, nullable=True),
+                              Column("episode", Integer, nullable=True),
+                              Column("quality", String, nullable=False))
+    LostFilmTVCredentials6 = Table("lostfilmtv_credentials", m6,
+                                   Column('username', String, primary_key=True),
+                                   Column('password', String, primary_key=True),
+                                   Column('session', String),
+                                   Column('cookies', String),
+                                   Column('headers', String),
+                                   Column('domain', String),
+                                   Column('default_quality', String, nullable=False, server_default='SD'))
 
     versions = [
         (LostFilmTVSeries0, LostFilmTVCredentials0),
@@ -97,6 +113,7 @@ class LostFilmTrackerUpgradeTest(UpgradeTestCase):
         (LostFilmTVSeries3, Topic3, LostFilmTVCredentials3),
         (LostFilmTVSeries4, Topic4, LostFilmTVCredentials4),
         (LostFilmTVSeries5, Topic5, LostFilmTVCredentials5),
+        (LostFilmTVSeries6, Topic6, LostFilmTVCredentials6),
     ]
 
     @classmethod
@@ -131,6 +148,9 @@ class LostFilmTrackerUpgradeTest(UpgradeTestCase):
 
     def test_updage_empty_from_version_4(self):
         self._upgrade_from(None, 4)
+
+    def test_updage_empty_from_version_5(self):
+        self._upgrade_from(None, 5)
 
     def test_updage_filled_from_version_0(self):
         topic1 = {'url': 'http://1', 'display_name': '1', 'search_name': '1'}

--- a/tests/plugins/trackers/tests_lostfilm/test_lostfilmtrackerplugin.py
+++ b/tests/plugins/trackers/tests_lostfilm/test_lostfilmtrackerplugin.py
@@ -104,7 +104,7 @@ class TestLostFilmTrackerPlugin(ReadContentMixin, DbTestCase):
         self.plugin.update_credentials({'username': 'monitorrent', 'password': 'monitorrent'})
         assert self.plugin.login() == LoginResult.Ok
 
-        login_mock.assert_called_with('monitorrent', 'monitorrent', {}, {}, 'www.lostfilmtv.site')
+        login_mock.assert_called_with('monitorrent', 'monitorrent', {}, {}, 'www.lostfilm.tv')
 
     def test_login_failed_incorrect_login_password(self):
         mock_tracker = LostFilmTVTracker()
@@ -115,7 +115,7 @@ class TestLostFilmTrackerPlugin(ReadContentMixin, DbTestCase):
         self.plugin.update_credentials({'username': 'monitorrent', 'password': 'monitorrent'})
         assert self.plugin.login() == LoginResult.IncorrentLoginPassword
 
-        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None, 'www.lostfilmtv.site')
+        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None, 'www.lostfilm.tv')
 
     def test_login_failed_unknown_1(self):
         mock_tracker = LostFilmTVTracker()
@@ -126,7 +126,7 @@ class TestLostFilmTrackerPlugin(ReadContentMixin, DbTestCase):
         self.plugin.update_credentials({'username': 'monitorrent', 'password': 'monitorrent'})
         assert self.plugin.login() == LoginResult.Unknown
 
-        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None, 'www.lostfilmtv.site')
+        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None, 'www.lostfilm.tv')
 
     def test_login_failed_unknown_2(self):
         mock_tracker = LostFilmTVTracker()
@@ -136,7 +136,7 @@ class TestLostFilmTrackerPlugin(ReadContentMixin, DbTestCase):
         self.plugin.update_credentials({'username': 'monitorrent', 'password': 'monitorrent'})
         assert self.plugin.login() == LoginResult.Unknown
 
-        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None, 'www.lostfilmtv.site')
+        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None, 'www.lostfilm.tv')
 
     def test_check_download(self):
         tracker = LostFilmPlugin()

--- a/tests/plugins/trackers/tests_lostfilm/test_lostfilmtrackerplugin.py
+++ b/tests/plugins/trackers/tests_lostfilm/test_lostfilmtrackerplugin.py
@@ -104,7 +104,7 @@ class TestLostFilmTrackerPlugin(ReadContentMixin, DbTestCase):
         self.plugin.update_credentials({'username': 'monitorrent', 'password': 'monitorrent'})
         assert self.plugin.login() == LoginResult.Ok
 
-        login_mock.assert_called_with('monitorrent', 'monitorrent', {}, {})
+        login_mock.assert_called_with('monitorrent', 'monitorrent', {}, {}, 'www.lostfilmtv.site')
 
     def test_login_failed_incorrect_login_password(self):
         mock_tracker = LostFilmTVTracker()
@@ -115,7 +115,7 @@ class TestLostFilmTrackerPlugin(ReadContentMixin, DbTestCase):
         self.plugin.update_credentials({'username': 'monitorrent', 'password': 'monitorrent'})
         assert self.plugin.login() == LoginResult.IncorrentLoginPassword
 
-        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None)
+        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None, 'www.lostfilmtv.site')
 
     def test_login_failed_unknown_1(self):
         mock_tracker = LostFilmTVTracker()
@@ -126,7 +126,7 @@ class TestLostFilmTrackerPlugin(ReadContentMixin, DbTestCase):
         self.plugin.update_credentials({'username': 'monitorrent', 'password': 'monitorrent'})
         assert self.plugin.login() == LoginResult.Unknown
 
-        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None)
+        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None, 'www.lostfilmtv.site')
 
     def test_login_failed_unknown_2(self):
         mock_tracker = LostFilmTVTracker()
@@ -136,7 +136,7 @@ class TestLostFilmTrackerPlugin(ReadContentMixin, DbTestCase):
         self.plugin.update_credentials({'username': 'monitorrent', 'password': 'monitorrent'})
         assert self.plugin.login() == LoginResult.Unknown
 
-        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None)
+        login_mock.assert_called_with('monitorrent', 'monitorrent', None, None, 'www.lostfilmtv.site')
 
     def test_check_download(self):
         tracker = LostFilmPlugin()
@@ -492,8 +492,8 @@ class TestLostFilmTrackerPlugin(ReadContentMixin, DbTestCase):
         info = self.plugin.get_topic_info(topic)
         assert info == expected
 
-    @data((LostFilmShow('Russian', u'Русский', "Russian", 666), u'Русский / Russian'),
-          (LostFilmShow('Not Parsed', None, 'Not_Parsed', 666), u'Not Parsed'))
+    @data((LostFilmShow('Russian', u'Русский', "Russian", 666, 'www.lostfilm.tv'), u'Русский / Russian'),
+          (LostFilmShow('Not Parsed', None, 'Not_Parsed', 666, 'www.lostfilm.tv'), u'Not Parsed'))
     @unpack
     def test_get_display_name(self, parsed_url, expected):
         # noinspection PyProtectedMember


### PR DESCRIPTION
Под фильтр плагина теперь попадают все домены с текстом `lostfilm`.