### PR TITLE
fix: connection status for qbittorrent plugin

### DIFF
--- a/monitorrent/plugins/clients/qbittorrent.py
+++ b/monitorrent/plugins/clients/qbittorrent.py
@@ -103,6 +103,7 @@ class QBittorrentClientPlugin(object):
     def check_connection(self):
         client = self.get_client()
         client.app_version()
+        return True
 
     def find_torrent(self, torrent_hash):
         client = self.get_client()


### PR DESCRIPTION
QBittorrent plugin didn't return any results of connection causing failed connection to server