### PR TITLE
Update transmission.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,15 +20,17 @@ FROM scratch AS mount
 COPY . /app
 
 FROM python:3.9.11-slim-bullseye
-MAINTAINER Alexander Puzynia <werwolf.by@gmail.com>
+LABEL maintainer="Alexander Puzynia <werwolf.by@gmail.com>"
 
-# For docker layers cahcing it is better to install Playwight first with all dependencies
+# For docker layers caching it is better to install Playwight first with all dependencies
 COPY --from=download /deb /deb
-RUN dpkg -i /deb/fonts-ubuntu_0.83-2_all.deb && \
+RUN apt update && apt install -y curl && \
+    dpkg -i /deb/fonts-ubuntu_0.83-2_all.deb && \
     dpkg -i /deb/ttf-ubuntu-font-family_0.83-2_all.deb && \
     rm -rf /deb/*.deb && \
     pip install playwright==1.31.1 && \
-    playwright install --with-deps firefox
+    playwright install --with-deps firefox && \
+    rm -rf /var/lib/apt/lists/*
 
 # requirements.txt is changed not often and again for caching let's install it first
 COPY ./requirements.txt /var/www/monitorrent/
@@ -41,5 +43,9 @@ COPY --from=build /app/dist /var/www/monitorrent
 WORKDIR /var/www/monitorrent
 
 EXPOSE 6687
+
+# Healthcheck
+HEALTHCHECK --interval=1m --timeout=5s --retries=3 --start-period=30s \
+  CMD curl -sS -o /dev/null -w "%{http_code}" http://localhost:6687 | grep -q 200 || exit 1
 
 CMD ["python", "server.py"]

--- a/monitorrent/plugins/clients/transmission.py
+++ b/monitorrent/plugins/clients/transmission.py
@@ -15,6 +15,7 @@ class TransmissionCredentials(Base):
     port = Column(Integer, nullable=False)
     username = Column(String, nullable=True)
     password = Column(String, nullable=True)
+    download_dir = Column(String, nullable=True)
 
 
 class TransmissionClientPlugin(object):
@@ -45,6 +46,11 @@ class TransmissionClientPlugin(object):
             'model': 'password',
             'flex': 50
         }]
+    }, {
+        'type': 'text',
+        'label': 'Download Directory',
+        'model': 'download_dir',
+        'placeholder': 'Leave empty to use default'
     }]
     DEFAULT_PORT = 9091
     SUPPORTED_FIELDS = ['download_dir']
@@ -54,7 +60,7 @@ class TransmissionClientPlugin(object):
             cred = db.query(TransmissionCredentials).first()
             if not cred:
                 return None
-            return {'host': cred.host, 'port': cred.port, 'username': cred.username}
+            return {'host': cred.host, 'port': cred.port, 'username': cred.username, 'download_dir': cred.download_dir}
 
     def set_settings(self, settings):
         with DBSession() as db:
@@ -66,6 +72,7 @@ class TransmissionClientPlugin(object):
             cred.port = settings.get('port', self.DEFAULT_PORT)
             cred.username = settings.get('username', None)
             cred.password = settings.get('password', None)
+            cred.download_dir = settings.get('download_dir', None)
 
     def check_connection(self):
         with DBSession() as db:
@@ -97,19 +104,34 @@ class TransmissionClientPlugin(object):
         return six.text_type(session.download_dir)
 
     def add_torrent(self, torrent, torrent_settings):
-        """
-        :type torrent: str
-        :type torrent_settings: clients.TopicSettings | None
-        """
-        client = self.check_connection()
-        if not client:
-            return False
-        torrent_settings_dict = {}
-        if torrent_settings is not None:
-            if torrent_settings.download_dir is not None:
-                torrent_settings_dict['download_dir'] = torrent_settings.download_dir
+    """
+    :type torrent: str
+    :type torrent_settings: clients.TopicSettings | None
+    """
+    if not torrent:
+        raise ValueError("Torrent data is required")
+    
+    client = self.check_connection()
+    if not client:
+        return False
+    
+    # Получаем сохранённый каталог для загрузки
+    with db_session() as db:
+        cred = db.query(TransmissionCredentials).first()
+        download_dir = cred.download_dir if cred else None
+    
+    # Подготавливаем параметры для добавления торрента
+    torrent_settings_dict = {}
+    if download_dir:
+        torrent_settings_dict['download-dir'] = download_dir
+    
+    try:
+        # Добавляем торрент с указанным каталогом для загрузки
         client.add_torrent(base64.b64encode(torrent).decode('utf-8'), **torrent_settings_dict)
         return True
+    except transmissionrpc.TransmissionError as e:
+        logger.error(f"Error adding torrent: {e}")
+        return False
 
     def remove_torrent(self, torrent_hash):
         client = self.check_connection()

--- a/monitorrent/plugins/clients/transmission.py
+++ b/monitorrent/plugins/clients/transmission.py
@@ -6,6 +6,7 @@ from monitorrent.db import Base, DBSession
 from monitorrent.plugin_managers import register_plugin
 import base64
 
+
 class TransmissionCredentials(Base):
     __tablename__ = "transmission_credentials"
 
@@ -14,7 +15,8 @@ class TransmissionCredentials(Base):
     port = Column(Integer, nullable=False)
     username = Column(String, nullable=True)
     password = Column(String, nullable=True)
-    download_dir = Column(String, nullable=True)  # Новое поле
+    download_dir = Column(String, nullable=True)
+
 
 class TransmissionClientPlugin(object):
     name = "transmission"
@@ -54,22 +56,14 @@ class TransmissionClientPlugin(object):
     SUPPORTED_FIELDS = ['download_dir']
 
     def get_settings(self):
-        with db_session() as db:
+        with DBSession() as db:
             cred = db.query(TransmissionCredentials).first()
             if not cred:
                 return None
-            return {
-                'host': cred.host,
-                'port': cred.port,
-                'username': cred.username,
-                'download_dir': cred.download_dir  # Новое поле
-            }
+            return {'host': cred.host, 'port': cred.port, 'username': cred.username, 'download_dir': cred.download_dir}
 
     def set_settings(self, settings):
-        if 'host' not in settings:
-            raise ValueError("Host is required")
-        
-        with db_session() as db:
+        with DBSession() as db:
             cred = db.query(TransmissionCredentials).first()
             if not cred:
                 cred = TransmissionCredentials()
@@ -78,27 +72,63 @@ class TransmissionClientPlugin(object):
             cred.port = settings.get('port', self.DEFAULT_PORT)
             cred.username = settings.get('username', None)
             cred.password = settings.get('password', None)
-            cred.download_dir = settings.get('download_dir', None)  # Новое поле
+            cred.download_dir = settings.get('download_dir', None)
 
-    def add_torrent(self, torrent, torrent_settings):
-        if not torrent:
-            raise ValueError("Torrent data is required")
-        
+    def check_connection(self):
+        with DBSession() as db:
+            cred = db.query(TransmissionCredentials).first()
+            if not cred:
+                return False
+            client = transmissionrpc.Client(address=cred.host, port=cred.port,
+                                            user=cred.username, password=cred.password)
+            return client
+
+    def find_torrent(self, torrent_hash):
         client = self.check_connection()
         if not client:
             return False
-        
+        try:
+            torrent = client.get_torrent(torrent_hash.lower(), ['id', 'hashString', 'addedDate', 'name'])
+            return {
+                "name": torrent.name,
+                "date_added": torrent.date_added.replace(tzinfo=reference.LocalTimezone()).astimezone(utc)
+            }
+        except KeyError:
+            return False
+
+    def get_download_dir(self):
+        client = self.check_connection()
+        if not client:
+            return None
+        session = client.get_session()
+        return six.text_type(session.download_dir)
+
+    def add_torrent(self, torrent, torrent_settings):
+        """
+        :type torrent: str
+        :type torrent_settings: clients.TopicSettings | None
+        """
+        client = self.check_connection()
+        if not client:
+            return False
         with db_session() as db:
             cred = db.query(TransmissionCredentials).first()
             download_dir = cred.download_dir if cred else None
-        
         torrent_settings_dict = {}
         if download_dir:
             torrent_settings_dict['download-dir'] = download_dir
-        
         try:
             client.add_torrent(base64.b64encode(torrent).decode('utf-8'), **torrent_settings_dict)
             return True
         except transmissionrpc.TransmissionError as e:
             logger.error(f"Error adding torrent: {e}")
             return False
+
+    def remove_torrent(self, torrent_hash):
+        client = self.check_connection()
+        if not client:
+            return False
+        client.remove_torrent(torrent_hash.lower(), delete_data=False)
+        return True
+
+register_plugin('client', 'transmission', TransmissionClientPlugin())

--- a/monitorrent/plugins/clients/transmission.py
+++ b/monitorrent/plugins/clients/transmission.py
@@ -50,7 +50,6 @@ class TransmissionClientPlugin(object):
         'type': 'text',
         'label': 'Download Directory',
         'model': 'download_dir',
-        'placeholder': 'Leave empty to use default'
     }]
     DEFAULT_PORT = 9091
     SUPPORTED_FIELDS = ['download_dir']
@@ -60,7 +59,7 @@ class TransmissionClientPlugin(object):
             cred = db.query(TransmissionCredentials).first()
             if not cred:
                 return None
-            return {'host': cred.host, 'port': cred.port, 'username': cred.username}
+            return {'host': cred.host, 'port': cred.port, 'username': cred.username, 'download_dir': cred.download_dir}
 
     def set_settings(self, settings):
         with DBSession() as db:
@@ -73,7 +72,6 @@ class TransmissionClientPlugin(object):
             cred.username = settings.get('username', None)
             cred.password = settings.get('password', None)
             cred.download_dir = settings.get('download_dir', None)
-            db.commit()
 
     def check_connection(self):
         with DBSession() as db:
@@ -112,16 +110,10 @@ class TransmissionClientPlugin(object):
         client = self.check_connection()
         if not client:
             return False
-
-        with DBSession() as db:
-          cred = db.query(TransmissionCredentials).first()
-          download_dir = cred.download_dir if cred else None
-
         torrent_settings_dict = {}
-        if download_dir:
-          torrent_settings_dict['download-dir'] = download_dir
-        elif torrent_settings is not None and torrent_settings.download_dir is not None:
-          torrent_settings_dict['download-dir'] = torrent_settings.download_dir
+        if torrent_settings is not None:
+            if torrent_settings.download_dir is not None:
+                torrent_settings_dict['download_dir'] = torrent_settings.download_dir
         client.add_torrent(base64.b64encode(torrent).decode('utf-8'), **torrent_settings_dict)
         return True
 

--- a/monitorrent/plugins/clients/transmission.py
+++ b/monitorrent/plugins/clients/transmission.py
@@ -16,6 +16,7 @@ class TransmissionCredentials(Base):
     username = Column(String, nullable=True)
     password = Column(String, nullable=True)
     download_dir = Column(String, nullable=True)
+    db.commit()
 
 
 class TransmissionClientPlugin(object):

--- a/monitorrent/plugins/clients/transmission.py
+++ b/monitorrent/plugins/clients/transmission.py
@@ -16,7 +16,6 @@ class TransmissionCredentials(Base):
     username = Column(String, nullable=True)
     password = Column(String, nullable=True)
     download_dir = Column(String, nullable=True)
-    db.commit()
 
 
 class TransmissionClientPlugin(object):
@@ -73,6 +72,8 @@ class TransmissionClientPlugin(object):
             cred.port = settings.get('port', self.DEFAULT_PORT)
             cred.username = settings.get('username', None)
             cred.password = settings.get('password', None)
+            cred.download_dir = settings.get('download_dir', None)
+            db.commit()
 
     def check_connection(self):
         with DBSession() as db:

--- a/monitorrent/plugins/clients/transmission.py
+++ b/monitorrent/plugins/clients/transmission.py
@@ -1,3 +1,11 @@
+import six
+import transmissionrpc
+from pytz import reference, utc
+from sqlalchemy import Column, Integer, String
+from monitorrent.db import Base, DBSession
+from monitorrent.plugin_managers import register_plugin
+import base64
+
 class TransmissionCredentials(Base):
     __tablename__ = "transmission_credentials"
 

--- a/monitorrent/plugins/clients/transmission.py
+++ b/monitorrent/plugins/clients/transmission.py
@@ -15,7 +15,6 @@ class TransmissionCredentials(Base):
     port = Column(Integer, nullable=False)
     username = Column(String, nullable=True)
     password = Column(String, nullable=True)
-    download_dir = Column(String, nullable=True)
 
 
 class TransmissionClientPlugin(object):
@@ -46,11 +45,6 @@ class TransmissionClientPlugin(object):
             'model': 'password',
             'flex': 50
         }]
-    }, {
-        'type': 'text',
-        'label': 'Download Directory',
-        'model': 'download_dir',
-        'placeholder': 'Leave empty to use default'
     }]
     DEFAULT_PORT = 9091
     SUPPORTED_FIELDS = ['download_dir']
@@ -60,7 +54,7 @@ class TransmissionClientPlugin(object):
             cred = db.query(TransmissionCredentials).first()
             if not cred:
                 return None
-            return {'host': cred.host, 'port': cred.port, 'username': cred.username, 'download_dir': cred.download_dir}
+            return {'host': cred.host, 'port': cred.port, 'username': cred.username}
 
     def set_settings(self, settings):
         with DBSession() as db:
@@ -72,7 +66,6 @@ class TransmissionClientPlugin(object):
             cred.port = settings.get('port', self.DEFAULT_PORT)
             cred.username = settings.get('username', None)
             cred.password = settings.get('password', None)
-            cred.download_dir = settings.get('download_dir', None)
 
     def check_connection(self):
         with DBSession() as db:
@@ -111,18 +104,12 @@ class TransmissionClientPlugin(object):
         client = self.check_connection()
         if not client:
             return False
-        with db_session() as db:
-            cred = db.query(TransmissionCredentials).first()
-            download_dir = cred.download_dir if cred else None
         torrent_settings_dict = {}
-        if download_dir:
-            torrent_settings_dict['download-dir'] = download_dir
-        try:
-            client.add_torrent(base64.b64encode(torrent).decode('utf-8'), **torrent_settings_dict)
-            return True
-        except transmissionrpc.TransmissionError as e:
-            logger.error(f"Error adding torrent: {e}")
-            return False
+        if torrent_settings is not None:
+            if torrent_settings.download_dir is not None:
+                torrent_settings_dict['download_dir'] = torrent_settings.download_dir
+        client.add_torrent(base64.b64encode(torrent).decode('utf-8'), **torrent_settings_dict)
+        return True
 
     def remove_torrent(self, torrent_hash):
         client = self.check_connection()

--- a/monitorrent/plugins/clients/transmission.py
+++ b/monitorrent/plugins/clients/transmission.py
@@ -15,7 +15,7 @@ class TransmissionCredentials(Base):
     port = Column(Integer, nullable=False)
     username = Column(String, nullable=True)
     password = Column(String, nullable=True)
-    download_dir = Column(String, nullable=True)
+    custom_download_dir = Column(String, nullable=True)
 
 
 class TransmissionClientPlugin(object):
@@ -47,9 +47,13 @@ class TransmissionClientPlugin(object):
             'flex': 50
         }]
     }, {
-        'type': 'text',
-        'label': 'Download Directory',
-        'model': 'download_dir',
+        'type': 'row',
+        'content': [{
+            'type': 'text',
+            'label': 'Download Dir',
+            'model': 'custom_download_dir',
+            'flex': 100
+        }]
     }]
     DEFAULT_PORT = 9091
     SUPPORTED_FIELDS = ['download_dir']
@@ -59,7 +63,7 @@ class TransmissionClientPlugin(object):
             cred = db.query(TransmissionCredentials).first()
             if not cred:
                 return None
-            return {'host': cred.host, 'port': cred.port, 'username': cred.username, 'download_dir': cred.download_dir}
+            return {'host': cred.host, 'port': cred.port, 'username': cred.username, 'custom_download_dir': cred.custom_download_dir}
 
     def set_settings(self, settings):
         with DBSession() as db:
@@ -71,7 +75,7 @@ class TransmissionClientPlugin(object):
             cred.port = settings.get('port', self.DEFAULT_PORT)
             cred.username = settings.get('username', None)
             cred.password = settings.get('password', None)
-            cred.download_dir = settings.get('download_dir', None)
+            cred.custom_download_dir = settings.get('custom_download_dir', None)
 
     def check_connection(self):
         with DBSession() as db:
@@ -110,6 +114,11 @@ class TransmissionClientPlugin(object):
         client = self.check_connection()
         if not client:
             return False
+        with DBSession() as db:
+            cred = db.query(TransmissionCredentials).first()
+            custom_download_dir = cred.custom_download_dir if cred else None
+        if custom_download_dir and torrent_settings is not None:
+            torrent_settings.download_dir = custom_download_dir
         torrent_settings_dict = {}
         if torrent_settings is not None:
             if torrent_settings.download_dir is not None:

--- a/monitorrent/plugins/clients/transmission.py
+++ b/monitorrent/plugins/clients/transmission.py
@@ -1,12 +1,3 @@
-import six
-import transmissionrpc
-from pytz import reference, utc
-from sqlalchemy import Column, Integer, String
-from monitorrent.db import Base, DBSession
-from monitorrent.plugin_managers import register_plugin
-import base64
-
-
 class TransmissionCredentials(Base):
     __tablename__ = "transmission_credentials"
 
@@ -15,8 +6,7 @@ class TransmissionCredentials(Base):
     port = Column(Integer, nullable=False)
     username = Column(String, nullable=True)
     password = Column(String, nullable=True)
-    download_dir = Column(String, nullable=True)
-
+    download_dir = Column(String, nullable=True)  # Новое поле
 
 class TransmissionClientPlugin(object):
     name = "transmission"
@@ -56,14 +46,22 @@ class TransmissionClientPlugin(object):
     SUPPORTED_FIELDS = ['download_dir']
 
     def get_settings(self):
-        with DBSession() as db:
+        with db_session() as db:
             cred = db.query(TransmissionCredentials).first()
             if not cred:
                 return None
-            return {'host': cred.host, 'port': cred.port, 'username': cred.username, 'download_dir': cred.download_dir}
+            return {
+                'host': cred.host,
+                'port': cred.port,
+                'username': cred.username,
+                'download_dir': cred.download_dir  # Новое поле
+            }
 
     def set_settings(self, settings):
-        with DBSession() as db:
+        if 'host' not in settings:
+            raise ValueError("Host is required")
+        
+        with db_session() as db:
             cred = db.query(TransmissionCredentials).first()
             if not cred:
                 cred = TransmissionCredentials()
@@ -72,69 +70,27 @@ class TransmissionClientPlugin(object):
             cred.port = settings.get('port', self.DEFAULT_PORT)
             cred.username = settings.get('username', None)
             cred.password = settings.get('password', None)
-            cred.download_dir = settings.get('download_dir', None)
-
-    def check_connection(self):
-        with DBSession() as db:
-            cred = db.query(TransmissionCredentials).first()
-            if not cred:
-                return False
-            client = transmissionrpc.Client(address=cred.host, port=cred.port,
-                                            user=cred.username, password=cred.password)
-            return client
-
-    def find_torrent(self, torrent_hash):
-        client = self.check_connection()
-        if not client:
-            return False
-        try:
-            torrent = client.get_torrent(torrent_hash.lower(), ['id', 'hashString', 'addedDate', 'name'])
-            return {
-                "name": torrent.name,
-                "date_added": torrent.date_added.replace(tzinfo=reference.LocalTimezone()).astimezone(utc)
-            }
-        except KeyError:
-            return False
-
-    def get_download_dir(self):
-        client = self.check_connection()
-        if not client:
-            return None
-        session = client.get_session()
-        return six.text_type(session.download_dir)
+            cred.download_dir = settings.get('download_dir', None)  # Новое поле
 
     def add_torrent(self, torrent, torrent_settings):
-    """
-    :type torrent: str
-    :type torrent_settings: clients.TopicSettings | None
-    """
-    if not torrent:
-        raise ValueError("Torrent data is required")
-    
-    client = self.check_connection()
-    if not client:
-        return False
-    
-    with db_session() as db:
-        cred = db.query(TransmissionCredentials).first()
-        download_dir = cred.download_dir if cred else None
-    
-    torrent_settings_dict = {}
-    if download_dir:
-        torrent_settings_dict['download-dir'] = download_dir
-    
-    try:
-        client.add_torrent(base64.b64encode(torrent).decode('utf-8'), **torrent_settings_dict)
-        return True
-    except transmissionrpc.TransmissionError as e:
-        logger.error(f"Error adding torrent: {e}")
-        return False
-
-    def remove_torrent(self, torrent_hash):
+        if not torrent:
+            raise ValueError("Torrent data is required")
+        
         client = self.check_connection()
         if not client:
             return False
-        client.remove_torrent(torrent_hash.lower(), delete_data=False)
-        return True
-
-register_plugin('client', 'transmission', TransmissionClientPlugin())
+        
+        with db_session() as db:
+            cred = db.query(TransmissionCredentials).first()
+            download_dir = cred.download_dir if cred else None
+        
+        torrent_settings_dict = {}
+        if download_dir:
+            torrent_settings_dict['download-dir'] = download_dir
+        
+        try:
+            client.add_torrent(base64.b64encode(torrent).decode('utf-8'), **torrent_settings_dict)
+            return True
+        except transmissionrpc.TransmissionError as e:
+            logger.error(f"Error adding torrent: {e}")
+            return False

--- a/monitorrent/plugins/clients/transmission.py
+++ b/monitorrent/plugins/clients/transmission.py
@@ -115,18 +115,15 @@ class TransmissionClientPlugin(object):
     if not client:
         return False
     
-    # Получаем сохранённый каталог для загрузки
     with db_session() as db:
         cred = db.query(TransmissionCredentials).first()
         download_dir = cred.download_dir if cred else None
     
-    # Подготавливаем параметры для добавления торрента
     torrent_settings_dict = {}
     if download_dir:
         torrent_settings_dict['download-dir'] = download_dir
     
     try:
-        # Добавляем торрент с указанным каталогом для загрузки
         client.add_torrent(base64.b64encode(torrent).decode('utf-8'), **torrent_settings_dict)
         return True
     except transmissionrpc.TransmissionError as e:

--- a/monitorrent/plugins/clients/transmission.py
+++ b/monitorrent/plugins/clients/transmission.py
@@ -15,6 +15,7 @@ class TransmissionCredentials(Base):
     port = Column(Integer, nullable=False)
     username = Column(String, nullable=True)
     password = Column(String, nullable=True)
+    download_dir = Column(String, nullable=True)
 
 
 class TransmissionClientPlugin(object):
@@ -45,6 +46,11 @@ class TransmissionClientPlugin(object):
             'model': 'password',
             'flex': 50
         }]
+    }, {
+        'type': 'text',
+        'label': 'Download Directory',
+        'model': 'download_dir',
+        'placeholder': 'Leave empty to use default'
     }]
     DEFAULT_PORT = 9091
     SUPPORTED_FIELDS = ['download_dir']
@@ -104,10 +110,16 @@ class TransmissionClientPlugin(object):
         client = self.check_connection()
         if not client:
             return False
+
+        with DBSession() as db:
+          cred = db.query(TransmissionCredentials).first()
+          download_dir = cred.download_dir if cred else None
+
         torrent_settings_dict = {}
-        if torrent_settings is not None:
-            if torrent_settings.download_dir is not None:
-                torrent_settings_dict['download_dir'] = torrent_settings.download_dir
+        if download_dir:
+          torrent_settings_dict['download-dir'] = download_dir
+        elif torrent_settings is not None and torrent_settings.download_dir is not None:
+          torrent_settings_dict['download-dir'] = torrent_settings.download_dir
         client.add_torrent(base64.b64encode(torrent).decode('utf-8'), **torrent_settings_dict)
         return True
 


### PR DESCRIPTION
### Что было изменено?
- Добавлено новое поле `download_dir` в модель `TransmissionCredentials`.
- Обновлена форма настроек для поддержки ручного ввода каталога загрузки.
- Изменён метод `add_torrent` для использования указанного каталога.

### Зачем это было изменено?
- Пользователи хотели иметь возможность указывать каталог для загрузки, отличный от стандартного `download-dir` в Transmission.
- Это позволяет гибко управлять загрузками для разных торрентов.

### Как это работает?
- В интерфейсе добавлено новое поле "Download Directory".
- При добавлении торрента, если указан каталог, он используется вместо стандартного.